### PR TITLE
Run Ansible Lint action only on PR and push to main

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -4,6 +4,12 @@ name: Ansible Lint
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - '**.yml'
+      - '**.yaml'
+  pull_request:
     paths:
       - '**.yml'
       - '**.yaml'
@@ -11,7 +17,7 @@ on:
 jobs:
   ansible-lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 8
 
     steps:
       - name: Git checkout


### PR DESCRIPTION
Since the action is slow at 4 minutes, don't do it on every push and frustrate everyone.